### PR TITLE
Solution for Ruby_Advance_Coding problem14

### DIFF
--- a/14/problem14.rb
+++ b/14/problem14.rb
@@ -1,0 +1,19 @@
+require 'deep_clone'
+
+class Person
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def name
+    DeepClone.clone(@name)
+  end
+
+
+end
+
+person1 = Person.new('James')
+person1.name.reverse!
+puts person1.name


### PR DESCRIPTION
The following code is flawed. It currently allows @name to be modified from outside the method via a destructive method call. Fix the code so that it returns a copy of @name instead of a reference to it.
class Person
  attr_reader :name

  def initialize(name)
    @name = name
  end
end

person1 = Person.new('James')
person1.name.reverse!
puts person1.name

OUTPUT: James
